### PR TITLE
Fix webserver bug to allocate the next lighthouse port correctly

### DIFF
--- a/nebula_lighthouse_service/webservice.py
+++ b/nebula_lighthouse_service/webservice.py
@@ -96,7 +96,7 @@ async def index():
 
 async def start_nebula(lighthouse: Lighthouse) -> Tuple[int, asyncio.subprocess.Process]:
     min_port, max_port = snap_config.get_ports()
-    port = min_port + len(nebula_lighthouses)
+    port = min_port + len(list(nebula_config.get_existing_configs()))
     if port > max_port:
         raise ValueError('Too many nebula lighthouse services already running')
 


### PR DESCRIPTION
Should fix #4.

We were calculating the next port to allocate based on the number of running lighthouse instances but this does not count instances that fail due to expired certificates or other failures.

This now finds the next port based on the existing configuration files.