### PR TITLE
update snap to core24 and python dependencies

### DIFF
--- a/nebula_lighthouse_service/webservice.py
+++ b/nebula_lighthouse_service/webservice.py
@@ -6,7 +6,7 @@ import logging
 import re
 from typing import Tuple
 
-import pkg_resources
+import importlib.resources
 from pydantic import BaseModel, validator
 import uvicorn as uvicorn
 from fastapi import FastAPI, File
@@ -91,7 +91,7 @@ async def shutdown():
 
 @app.get("/")
 async def index():
-    return HTMLResponse(pkg_resources.resource_string(__name__, 'static/index.html'))
+    return HTMLResponse(importlib.resources.files(__name__).joinpath('static/index.html').read_bytes())
 
 
 async def start_nebula(lighthouse: Lighthouse) -> Tuple[int, asyncio.subprocess.Process]:

--- a/setup.py
+++ b/setup.py
@@ -10,11 +10,11 @@ setup(
     packages=find_packages(),
     package_data=dict(nebula_lighthouse_service=["static/*.html"]),
     install_requires=[
-        'fastapi==0.75.1',
-        'PyYAML==6.0',
-        'uvicorn==0.17.6',
-        'pydantic==1.9.0',
-        'python-multipart==0.0.5',
+        'fastapi==0.116.1',
+        'PyYAML==6.0.2',
+        'uvicorn==0.35.0',
+        'pydantic==1.10.21',
+        'python-multipart==0.0.20',
     ],
     scripts=[
         './nebula_lighthouse_service/configure_hook.py',

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -1,5 +1,5 @@
 #!/bin/sh
 
-export PYTHONPATH=$SNAP/lib/python3.8/site-packages
+export PYTHONPATH=$SNAP/lib/python3.12/site-packages
 
 $SNAP/bin/configure_hook.py

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -25,7 +25,7 @@ description: |
 grade: stable
 confinement: strict
 
-base: core20
+base: core24
 
 parts:
   nebula:
@@ -35,6 +35,7 @@ parts:
     source-type: git
     build-packages:
       - gcc
+      - golang-go
 
   webservice:
     plugin: python


### PR DESCRIPTION
Bringing the snap core up to the latest as core20 was out of standard support.

~~Marking as draft as tested basic functions but have not gone through everything yet.~~
Tested with valid and invalid inputs and seems to be behaving the same as the current version.

## Changes worth noting
### python 3.8 > 3.12
- pkg_resources migrated to importlib.resources
- all python dependencies updated to the latest except pydantic (latest v1)
### fastapi
 - from version 0.112.0 much less dependencies are included by default giving a slightly smaller snap
### core24
- go-lang not included by default so added when building nebula