### PR TITLE
Add ability to run outside a snap

### DIFF
--- a/example/config.yaml
+++ b/example/config.yaml
@@ -1,0 +1,3 @@
+min-port: 49152
+max-port: 65535
+webserver.port: 8080

--- a/nebula_lighthouse_service/nebula_config.py
+++ b/nebula_lighthouse_service/nebula_config.py
@@ -3,11 +3,16 @@ from typing import Iterator, Tuple
 
 import yaml
 import os
+import shutil
 from pathlib import Path
 
-SNAP = Path(os.environ['SNAP'])
-CONFIG_PATH = Path(os.environ['SNAP_COMMON']) / 'config'
-
+NEBULA_PATH = Path(shutil.which('nebula')).parent
+try:
+    CONFIG_PATH = Path(os.environ['SNAP_COMMON']) / 'config'
+    IS_SNAP = True
+except KeyError:
+    CONFIG_PATH = Path('/etc/nebula-lighthouse-service')
+    IS_SNAP = False
 
 def create_config(ca: str, cert: str, key: str, port: int) -> str:
     cfg = dict(
@@ -29,7 +34,7 @@ def create_config(ca: str, cert: str, key: str, port: int) -> str:
 
 
 def test_config(yaml_config: str):
-    subprocess.run(f'{SNAP}/bin/nebula -test -config /dev/stdin'.split(),
+    subprocess.run(f'{NEBULA_PATH}/nebula -test -config /dev/stdin'.split(),
                    check=True,
                    input=yaml_config.encode())
 

--- a/nebula_lighthouse_service/web_config.py
+++ b/nebula_lighthouse_service/web_config.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import subprocess
+import yaml
+import pathlib
+from nebula_lighthouse_service.nebula_config import CONFIG_PATH
+
+def get_config(name, default):
+    try:
+        contents = (CONFIG_PATH / 'config.yaml').read_text()
+        cfg = yaml.safe_load(contents)
+        output = cfg[name]
+    except:
+        return default
+    return output
+
+
+def get_ports():
+    min_port = max(1, int(get_config('min-port', 49152)))
+    max_port = min(65535, int(get_config('max-port', 65535)))
+    return min_port, max_port
+
+
+def get_webserver_port():
+    port = min(65535, max(1, int(get_config('webserver.port', 8080))))
+    return port
+

--- a/nebula_lighthouse_service/webservice.py
+++ b/nebula_lighthouse_service/webservice.py
@@ -12,7 +12,7 @@ import uvicorn as uvicorn
 from fastapi import FastAPI, File
 from starlette.responses import HTMLResponse
 
-from nebula_lighthouse_service import snap_config, nebula_config
+from nebula_lighthouse_service import snap_config, nebula_config, web_config
 from nebula_lighthouse_service.nebula_config import NEBULA_PATH, IS_SNAP
 
 app = FastAPI()
@@ -95,7 +95,10 @@ async def index():
 
 
 async def start_nebula(lighthouse: Lighthouse) -> Tuple[int, asyncio.subprocess.Process]:
-    min_port, max_port = snap_config.get_ports()
+    if IS_SNAP:
+        min_port, max_port = snap_config.get_ports()
+    else:
+        min_port, max_port = web_config.get_ports()
     port = min_port + len(list(nebula_config.get_existing_configs()))
     if port > max_port:
         raise ValueError('Too many nebula lighthouse services already running')
@@ -159,7 +162,8 @@ def main():
     if IS_SNAP:
         port = snap_config.get_webserver_port()
     else:
-        port = 8080
+        port = web_config.get_webserver_port()
+
     uvicorn.run(app, host="0.0.0.0", port=port)
 
 

--- a/nebula_lighthouse_service/webservice.py
+++ b/nebula_lighthouse_service/webservice.py
@@ -13,7 +13,7 @@ from fastapi import FastAPI, File
 from starlette.responses import HTMLResponse
 
 from nebula_lighthouse_service import snap_config, nebula_config
-from nebula_lighthouse_service.nebula_config import SNAP
+from nebula_lighthouse_service.nebula_config import NEBULA_PATH, IS_SNAP
 
 app = FastAPI()
 
@@ -73,7 +73,7 @@ async def startup():
             continue
         log.info('starting nebula', path, port)
 
-        cmd = [f'{SNAP}/bin/nebula', '-config', path]
+        cmd = [f'{NEBULA_PATH}/nebula', '-config', path]
         proc = await asyncio.create_subprocess_exec(*cmd)
 
         lighthouse = Lighthouse(ca_crt=ca_crt, host_crt=host_crt, host_key=host_key)
@@ -106,7 +106,7 @@ async def start_nebula(lighthouse: Lighthouse) -> Tuple[int, asyncio.subprocess.
     path = nebula_config.get_config_path(port)
     path.write_text(config)
 
-    cmd = [f'{SNAP}/bin/nebula', '-config', path]
+    cmd = [f'{NEBULA_PATH}/nebula', '-config', path]
     proc = await asyncio.create_subprocess_exec(*cmd)
     return port, proc
 
@@ -156,7 +156,10 @@ async def lighthouse_status(ca_crt: bytes = File(...),
 
 
 def main():
-    port = snap_config.get_webserver_port()
+    if IS_SNAP:
+        port = snap_config.get_webserver_port()
+    else:
+        port = 8080
     uvicorn.run(app, host="0.0.0.0", port=port)
 
 


### PR DESCRIPTION
Thought I would finally tackle making this run outside a snap.

The logic is
- detect if it's running in a snap by looking for the SNAP environment variable
- if running in a snap use existing snap_config.py
- else use web_config.py which loads config.yaml from CONFIG_PATH 

this does open the config file every time we get a config value, it's probably a better ideal to load the values at start up but this behavior is closer to what the snap does.

nebula path is also based on looking in $PATH first.
