### PR TITLE
split out lighthouse-port.yaml

### DIFF
--- a/nebula_lighthouse_service/nebula_config.py
+++ b/nebula_lighthouse_service/nebula_config.py
@@ -9,9 +9,11 @@ from pathlib import Path
 NEBULA_PATH = Path(shutil.which('nebula')).parent
 try:
     CONFIG_PATH = Path(os.environ['SNAP_COMMON']) / 'config'
+    VAR_PATH = CONFIG_PATH
     IS_SNAP = True
 except KeyError:
     CONFIG_PATH = Path('/etc/nebula-lighthouse-service')
+    VAR_PATH = Path('/var/lib/nebula-lighthouse-service')
     IS_SNAP = False
 
 def create_config(ca: str, cert: str, key: str, port: int) -> str:
@@ -53,8 +55,8 @@ def read_config(path: Path) -> Tuple[str, str, str, int]:
 
 
 def get_existing_configs() -> Iterator[Path]:
-    return CONFIG_PATH.glob('lighthouse-*.yaml')
+    return VAR_PATH.glob('lighthouse-*.yaml')
 
 
 def get_config_path(lighthouse_index: int) -> Path:
-    return CONFIG_PATH / f'lighthouse-{int(lighthouse_index)}.yaml'
+    return VAR_PATH / f'lighthouse-{int(lighthouse_index)}.yaml'

--- a/nebula_lighthouse_service/nebula_config.py
+++ b/nebula_lighthouse_service/nebula_config.py
@@ -58,5 +58,5 @@ def get_existing_configs() -> Iterator[Path]:
     return VAR_PATH.glob('lighthouse-*.yaml')
 
 
-def get_config_path(lighthouse_index: int) -> Path:
+def get_lighthouse_path(lighthouse_index: int) -> Path:
     return VAR_PATH / f'lighthouse-{int(lighthouse_index)}.yaml'

--- a/nebula_lighthouse_service/nebula_config.py
+++ b/nebula_lighthouse_service/nebula_config.py
@@ -9,11 +9,11 @@ from pathlib import Path
 NEBULA_PATH = Path(shutil.which('nebula')).parent
 try:
     CONFIG_PATH = Path(os.environ['SNAP_COMMON']) / 'config'
-    VAR_PATH = CONFIG_PATH
+    LIGHTHOUSE_PATH = CONFIG_PATH
     IS_SNAP = True
 except KeyError:
     CONFIG_PATH = Path('/etc/nebula-lighthouse-service')
-    VAR_PATH = Path('/var/lib/nebula-lighthouse-service')
+    LIGHTHOUSE_PATH = Path('/var/lib/nebula-lighthouse-service')
     IS_SNAP = False
 
 def create_config(ca: str, cert: str, key: str, port: int) -> str:
@@ -55,8 +55,8 @@ def read_config(path: Path) -> Tuple[str, str, str, int]:
 
 
 def get_existing_configs() -> Iterator[Path]:
-    return VAR_PATH.glob('lighthouse-*.yaml')
+    return LIGHTHOUSE_PATH.glob('lighthouse-*.yaml')
 
 
 def get_lighthouse_path(lighthouse_index: int) -> Path:
-    return VAR_PATH / f'lighthouse-{int(lighthouse_index)}.yaml'
+    return LIGHTHOUSE_PATH / f'lighthouse-{int(lighthouse_index)}.yaml'

--- a/nebula_lighthouse_service/webservice.py
+++ b/nebula_lighthouse_service/webservice.py
@@ -106,7 +106,7 @@ async def start_nebula(lighthouse: Lighthouse) -> Tuple[int, asyncio.subprocess.
     config = nebula_config.create_config(lighthouse.ca_crt, lighthouse.host_crt, lighthouse.host_key, port)
     nebula_config.test_config(config)
 
-    path = nebula_config.get_config_path(port)
+    path = nebula_config.get_lighthouse_path(port)
     path.write_text(config)
 
     cmd = [f'{NEBULA_PATH}/nebula', '-config', path]


### PR DESCRIPTION
As per #10 moving  lighthouse-port.yaml files to  a /var will is better for packaging.
`LIGHTHOUSE_PATH = CONFIG_PATH` in snaps keep compatibility with existing deployments.

Keeping draft till I do more testing with snap.