### PR TITLE
snap update nebula v1.9.7

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -31,7 +31,7 @@ parts:
   nebula:
     plugin: go
     source: https://github.com/slackhq/nebula.git
-    source-tag: v1.9.6
+    source-tag: v1.9.7
     source-type: git
     build-packages:
       - gcc


### PR DESCRIPTION
Minor bump from nebula.
There is a security issue but does not sound like it would have much of an effect in our usage.

> Security
> 
>     Fix an issue where Nebula could incorrectly accept and process a packet from an erroneous source IP when the sender's
>     certificate is configured with unsafe_routes (cert v1/v2) or multiple IPs (cert v2). (https://github.com/slackhq/nebula/pull/1494)
> 
> Changed
> 
>     Disable sending recv_error messages when a packet is received outside the allowable counter window. (https://github.com/slackhq/nebula/pull/1459)
>     Improve error messages and remove some unnecessary fatal conditions in the Windows and generic udp listener. (https://github.com/slackhq/nebula/pull/1453)