### PR TITLE
nebula 1.10.0 compatibility

### DIFF
--- a/nebula_lighthouse_service/webservice.py
+++ b/nebula_lighthouse_service/webservice.py
@@ -28,7 +28,7 @@ RE_NEBULA = re.compile(r'^[ A-Za-z0-9+/\r\n-=]+$')
 
 
 def is_nebula_crt(crt: str) -> str:
-    if RE_NEBULA.match(crt) and crt.startswith('-----BEGIN NEBULA CERTIFICATE-----'):
+    if RE_NEBULA.match(crt) and crt.startswith('-----BEGIN NEBULA CERTIFICATE'):
         return crt
     else:
         raise ValueError('must be a valid NEBULA CERTIFICATE')

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -31,11 +31,12 @@ parts:
   nebula:
     plugin: go
     source: https://github.com/slackhq/nebula.git
-    source-tag: v1.9.7
+    source-tag: v1.10.0
     source-type: git
+    build-snaps:
+      - go/latest/stable
     build-packages:
       - gcc
-      - golang-go
 
   webservice:
     plugin: python


### PR DESCRIPTION
[nebula v1.10.0 is out](https://github.com/slackhq/nebula/releases/tag/v1.10.0) and v2 cert will start being used.

Older versions of nebula will fail with v2 certs so we will need to bump nebula in the snap.
Go version in the snap environment also needed updating for v1.10.0  .

~~Looking into IPv6 support.~~ 

v2 certificates have a slightly different start so making the match a bit less strict seemed appropriate.

Example of cert start.
v1
`-----BEGIN NEBULA CERTIFICATE-----`

v2
`-----BEGIN NEBULA CERTIFICATE V2-----`